### PR TITLE
PCRTC: Fix video modes higher than 480P

### DIFF
--- a/plugins/GSdx/GS.h
+++ b/plugins/GSdx/GS.h
@@ -1284,3 +1284,7 @@ enum stateType {ST_WRITE, ST_TRANSFER, ST_VSYNC};
 // default gs config settings
 #define DEFAULT_EXTRA_RENDERING_THREADS 2
 
+// GS Video modes macros
+#define Vmode_VESA (m_regs->SMODE1.CMOD == 0)
+#define Vmode_NTSC (m_regs->SMODE1.CMOD == 2)
+#define Vmode_PAL  (m_regs->SMODE1.CMOD == 3)

--- a/plugins/GSdx/GSRenderer.cpp
+++ b/plugins/GSdx/GSRenderer.cpp
@@ -218,7 +218,6 @@ bool GSRenderer::Merge(int field)
 		if(dr[i].height() > 512) // hmm
 		{
 			int y = GetDeviceSize(i).y;
-			if(m_regs->SMODE2.INT && m_regs->SMODE2.FFMD) y /= 2;
 			r.bottom = r.top + y;
 		}
 

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -354,7 +354,7 @@ GSVector4i GSState::GetDisplayRect(int i)
 	GSVector4i r;
 
 	//Some games (such as Pool Paradise) use alternate line reading and provide a massive height which is really half.
-	if (height > 640 && m_regs->SMODE1.CMOD!=0) // Vmode's other than NTSC/PAL need height value over 640.
+	if (height > 640 && !Vmode_VESA)
 	{
 		height /= 2;
 	}
@@ -385,7 +385,7 @@ GSVector4i GSState::GetFrameRect(int i)
 //  Some NTSC mode games request higher height values for accurate display size / position when width is 640
 //  Testcases : PS logo (640x512) , Resident Evil:CVX (640x480). potentially more test cases...
 
-	if (m_regs->SMODE1.CMOD == 2 && h > 448 && w < 640)
+	if (Vmode_NTSC && h > 448 && w < 640)
 		h = 448;
 
 	if (m_regs->SMODE2.INT && m_regs->SMODE2.FFMD && h > 1)
@@ -470,7 +470,7 @@ float GSState::GetTvRefreshRate()
   // TODO: Frequencies for VESA / DTV : http://users.neoscientists.org/~blue/ps2videomodes.txt
   // SMODE1 PLL Loop divider (LC) could be used for detection of other video modes. CMOD's only useful for NTSC/PAL.(2/3)
 
-	return (m_regs->SMODE1.CMOD & 1) ? 50 : (60/1.001f);
+	return (Vmode_PAL) ? 50 : (60/1.001f);
 }
 
 // GIFPackedRegHandler*

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -364,6 +364,9 @@ GSVector4i GSState::GetDisplayRect(int i)
 	r.right = r.left + width;
 	r.bottom = r.top + height;
 
+	// Useful for debugging games:
+	//printf("DW: %d , DH: %d , left: %d , right: %d , top: %d , down: %d , MAGH: %d , MAGV: %d\n", m_regs->DISP[i].DISPLAY.DW, m_regs->DISP[i].DISPLAY.DH, r.left, r.right, r.top, r.bottom , m_regs->DISP[i].DISPLAY.MAGH,m_regs->DISP[i].DISPLAY.MAGV);
+
 	return r;
 }
 

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -349,22 +349,21 @@ void GSState::ResetHandlers()
 GSVector4i GSState::GetDisplayRect(int i)
 {
 	if(i < 0) i = IsEnabled(1) ? 1 : 0;
-	int height = m_regs->DISP[i].DISPLAY.DH + 1;
-	int width = m_regs->DISP[i].DISPLAY.DW + 1;
+	int height = (m_regs->DISP[i].DISPLAY.DH + 1) / (m_regs->DISP[i].DISPLAY.MAGV + 1);
+	int width = (m_regs->DISP[i].DISPLAY.DW + 1) / (m_regs->DISP[i].DISPLAY.MAGH + 1);
 	GSVector4i r;
 
 	//Some games (such as Pool Paradise) use alternate line reading and provide a massive height which is really half.
-	if (height > 640) 
+	if (height > 640 && m_regs->SMODE1.CMOD!=0) // Vmode's other than NTSC/PAL need height value over 640.
 	{
 		height /= 2;
 	}
 
-	
 	r.left = m_regs->DISP[i].DISPLAY.DX / (m_regs->DISP[i].DISPLAY.MAGH + 1);
 	r.top = m_regs->DISP[i].DISPLAY.DY / (m_regs->DISP[i].DISPLAY.MAGV + 1);
-	r.right = r.left + width / (m_regs->DISP[i].DISPLAY.MAGH + 1);
-	r.bottom = r.top + height / (m_regs->DISP[i].DISPLAY.MAGV + 1);
-	
+	r.right = r.left + width;
+	r.bottom = r.top + height;
+
 	return r;
 }
 


### PR DESCRIPTION
**Summary of changes:**

* Properly Initialize the height , width value. we previously only initialize the DH, DW register values which aren't the exact height/width. I'm actually surprised that the older check for height (pool paradise) worked ! It's usually not a problem since MAGV value is usually 0 at most instances. The correct formula for width and height are ``(DW + 1) / (MAGH +1)`` and ``(DH + 1) / (MAGV + 1)``.

* Add a nice print debug message to easily debug games by uncommenting the code. ( I can understand if you don't want this commit though )

* Allow 640+ height values for all Vmodes except PAL/NTSC as they need the higher height value for proper display size. 

**Additional Information:**
Here's a nice picture to explain the role of the Display register values :

![pic](http://ultraimg.com/images/crt.jpg)



**Example of observed changes of the commit:**


**1080P (before commit)**
![wrong](http://ultraimg.com/images/gsdx_20160120023759.png)

**1080P (after commit)**
![correct](http://ultraimg.com/images/gsdx_20160120021153.png)
